### PR TITLE
Use a PublisherMemberFunction instance in the example of the same name

### DIFF
--- a/rcljava_examples/src/main/java/org/ros2/rcljava/examples/publisher/PublisherMemberFunction.java
+++ b/rcljava_examples/src/main/java/org/ros2/rcljava/examples/publisher/PublisherMemberFunction.java
@@ -50,6 +50,6 @@ public class PublisherMemberFunction extends BaseComposableNode {
     // Initialize RCL
     RCLJava.rclJavaInit();
 
-    RCLJava.spin(new PublisherLambda());
+    RCLJava.spin(new PublisherMemberFunction());
   }
 }


### PR DESCRIPTION
I'm pretty sure this was a copy-paste error.